### PR TITLE
chore(deps): bump python-multipart and safety

### DIFF
--- a/bleu-os/requirements-server.txt
+++ b/bleu-os/requirements-server.txt
@@ -16,7 +16,7 @@ pyasn1>=0.6.2
 pydantic-settings>=2.10.1
 pyjwt>=2.10.1
 python-dotenv>=1.2.2,<1.3
-python-multipart>=0.0.27,<0.0.30
+python-multipart>=0.0.27,<0.0.31
 redis>=6.2,<8.0
 requests>=2.32.4
 sqlalchemy==2.0.50

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ h11 = {version = "0.16.0", optional = true}
 pyjwt = {version = "^2.10.1", optional = true}
 passlib = {version = "^1.7.4", optional = true}
 redis = {version = ">=6.2,<9.0", optional = true}
-python-multipart = {version = ">=0.0.27,<0.0.30", optional = true}
+python-multipart = {version = ">=0.0.27,<0.0.31", optional = true}
 prometheus-client = {version = ">=0.23.1,<0.26.0", optional = true}
 cryptography = {version = ">=46.0.5,<49.0.0", optional = true}
 sparse = {version = ">=0.17,<0.19", optional = true}

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -47,7 +47,7 @@ python-dotenv>=0.20.0
 # Quantum computing
 qiskit>=1.4.2
 requests>=2.32.4
-safety>=3.7.0
+safety>=3.8.1
 scikit-learn>=1.2.2
 
 # Database

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,5 +19,5 @@ pytest-asyncio>=0.21.1
 pytest-cov>=6.1.1
 # Documentation and packaging
 readme_renderer>=44.0
-safety>=3.7.0
+safety>=3.8.1
 twine>=6.2.0

--- a/requirements-secure.txt
+++ b/requirements-secure.txt
@@ -47,7 +47,7 @@ qiskit>=2.1.1
 redis>=6.3.0
 requests>=2.32.4
 rich>=15.0.0
-safety>=3.7.0
+safety>=3.8.1
 scikit-learn>=1.7.1
 
 # Database security

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ redis>=6.3.0
 # Additional utilities
 requests>=2.32.4
 rich>=15.0.0
-safety>=3.7.0
+safety>=3.8.1
 scikit-learn>=1.7.1
 sqlalchemy>=2.0.42
 # Updated to fix DoS vulnerability CVE-2025-62727 (Issues #302, #303)


### PR DESCRIPTION
## Summary
- Supersedes dependabot PR #191: allow `python-multipart` 0.0.30 (`>=0.0.27,<0.0.31`) in `pyproject.toml` and `bleu-os/requirements-server.txt`
- Supersedes dependabot PR #188: bump `safety` from `>=3.7.0` to `>=3.8.1` across requirements files
- Rebases both updates onto current `main` (PR #191 had merge conflicts after recent merges)

## Test plan
- [ ] CI pipeline passes (lint, security scan, test suite)
- [ ] Close/supersede dependabot PRs #188 and #191 after merge


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only version constraint updates with no runtime or auth logic changes; risk is limited to resolver/CI picking newer patch/minor dependency versions.
> 
> **Overview**
> Bumps dependency pins only—no application code changes.
> 
> **`python-multipart`:** The allowed range is widened from `<0.0.30` to `<0.0.31` (still `>=0.0.27`) in `pyproject.toml` and `bleu-os/requirements-server.txt`, so installs can pick **0.0.30** for the server stack.
> 
> **`safety`:** The minimum version moves from `>=3.7.0` to `>=3.8.1` in `requirements.txt`, `requirements-ci.txt`, `requirements-dev.txt`, and `requirements-secure.txt`, aligning CI/dev/security requirement sets with a newer Safety release.
> 
> This consolidates superseded Dependabot updates onto current `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3da0d7352dfc0c108156cf9af0a8a4e57fcb30f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->