### PR TITLE
docs: unify develop-from-source workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ We welcome contributions. The full guide is in the docs:
 
 **Backend:** The Node/Express API lives in a [separate repo](docs/BACKEND_REPO.md). For backend-only changes, open issues and PRs in [HelloblueAI/Bleujs.-backend](https://github.com/HelloblueAI/Bleujs.-backend). See [Repositories and sync](docs/REPOSITORIES.md) for how both repos fit together.
 
+**Develop from source:** clone → `python -m venv .venv` → `pip install -e .` → set `BLEUJS_API_KEY` in `.env` → `bleu chat "Hello"`. Details: [Development setup](docs/CONTRIBUTING.md#-development-setup).
+
 Quick links:
 
 - [Code of Conduct](CODE_OF_CONDUCT.md)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,30 @@ print(BleuAPIClient().chat([{"role": "user", "content": "Say hello."}]).content)
 
 ---
 
+### For developers (clone & contribute)
+
+**End users** install from PyPI (`pip install bleu-js` above). **Contributors and maintainers** work from a clone:
+
+```bash
+git clone https://github.com/HelloblueAI/Bleu.js.git && cd Bleu.js
+python -m venv .venv && source .venv/bin/activate   # Windows: .venv\Scripts\activate
+pip install -e .                                    # SDK + CLI (same as requirements.txt)
+echo 'BLEUJS_API_KEY=bleujs_sk_...' > .env          # or cp .env.example .env for self-host
+set -a && source .env && set +a                     # Linux/macOS; or: export BLEUJS_API_KEY=...
+bleu chat "Hello"
+```
+
+| Need | Install |
+|------|---------|
+| SDK + CLI (daily dev) | `pip install -e .` |
+| Tests / CI parity | `pip install -e ".[ci]"` |
+| Self-host FastAPI app | `pip install -e ".[server]"` |
+| Full ML + quantum + server | `pip install -e ".[all]"` |
+
+**Full setup:** [Contributing → Development setup](docs/CONTRIBUTING.md#-development-setup) · [Install from source](docs/INSTALLATION.md#using-pip-from-source). The Node API lives in [Bleujs.-backend](https://github.com/HelloblueAI/Bleujs.-backend) — not required for `bleu chat` against [bleujs.org](https://bleujs.org).
+
+---
+
 ### Install & first run (details)
 
 **Requirements:** Python 3.11+
@@ -534,9 +558,9 @@ pip install bleu-js
 If you encounter dependency conflicts, try:
 
 ```bash
-# Use virtual environment
-python3 -m venv bleujs-env
-source bleujs-env/bin/activate
+# Use a virtual environment
+python3 -m venv .venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
 pip install bleu-js
 ```
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -120,6 +120,8 @@ You don't need to write code to contribute! Here are many ways to help:
 
 ## 🛠️ Development Setup
 
+Canonical guide for **working from a clone**. End users who only call the hosted API should use `pip install bleu-js` from PyPI ([Get started](GET_STARTED.md)).
+
 ### Prerequisites
 
 - **Python:** 3.11+
@@ -127,83 +129,86 @@ You don't need to write code to contribute! Here are many ways to help:
 - **IDE:** VS Code, PyCharm, or your favorite editor
 - **Docker:** (Optional, for containerized development)
 
-### Step-by-Step Setup
+### Daily workflow (SDK + hosted API)
 
-#### 1. Fork the Repository
+Most contributor work — CLI, SDK, docs, light tests — needs only the slim editable install:
 
 ```bash
-# Go to https://github.com/HelloblueAI/Bleu.js
-# Click "Fork" button in top-right corner
+git clone https://github.com/YOUR_USERNAME/Bleu.js.git   # fork first, or HelloblueAI/Bleu.js
+cd Bleu.js
+python -m venv .venv
+source .venv/bin/activate          # Windows: .venv\Scripts\activate
+
+pip install -e .                   # SDK + CLI — same as requirements.txt
+
+# API key for bleujs.org (create at https://bleujs.org)
+echo 'BLEUJS_API_KEY=bleujs_sk_...' > .env
+set -a && source .env && set +a    # Linux/macOS; or: export BLEUJS_API_KEY=...
+
+bleu chat "Hello"
+bleu version
 ```
 
-#### 2. Clone Your Fork
+Use a **single `.env` at the repo root** for local secrets. Do not commit `.env`. For self-hosting the FastAPI app you need more vars — copy [`.env.example`](../.env.example).
+
+### Step-by-step setup
+
+#### 1. Fork and clone
 
 ```bash
-# Replace YOUR_USERNAME with your GitHub username
+# Fork at https://github.com/HelloblueAI/Bleu.js, then:
 git clone https://github.com/YOUR_USERNAME/Bleu.js.git
 cd Bleu.js
-```
-
-#### 3. Add Upstream Remote
-
-```bash
 git remote add upstream https://github.com/HelloblueAI/Bleu.js.git
-git remote -v  # Verify remotes
 ```
 
-#### 4. Create Virtual Environment
+#### 2. Virtual environment
 
 ```bash
-# Create virtual environment
-python -m venv bleujs-env
-
-# Activate (Linux/macOS)
-source bleujs-env/bin/activate
-
-# Activate (Windows)
-bleujs-env\Scripts\activate
-
-# Activate (PowerShell)
-bleujs-env\Scripts\Activate.ps1
+python -m venv .venv
+source .venv/bin/activate          # Windows: .venv\Scripts\activate
 ```
 
-#### 5. Install Dependencies
+#### 3. Install dependencies
 
-**What to use from now on:** If `poetry` fails (e.g. `PoetryCoreException` / `InvalidRequirement`), use Poetry via pipx: see [Poetry: what to use from now on](POETRY_FIX.md).
+**Canonical source:** [`pyproject.toml`](../pyproject.toml) extras. `requirements*.txt` files are thin wrappers for CI and deploy — prefer `pip install -e ".[extra]"` when developing.
+
+| Goal | Command | `requirements*.txt` alias |
+|------|---------|---------------------------|
+| SDK + CLI (default) | `pip install -e .` | `requirements.txt` |
+| Self-host FastAPI app | `pip install -e ".[server]"` | `requirements-server-extra.txt` |
+| ML stack | `pip install -e ".[ml]"` | — |
+| Quantum stack | `pip install -e ".[quantum]"` | — |
+| CI / full test stack | `pip install -e ".[ci]"` | `requirements-ci.txt` |
+| Full product stack | `pip install -e ".[all]"` | `requirements-all.txt` |
+| Elastic Beanstalk (repo root) | `pip install -r requirements-elasticbeanstalk.txt` | → `requirements-all.txt` |
+| Lint / test tools | `pip install -r requirements-dev.txt` | after editable install |
 
 ```bash
-# Recommended: use Poetry with all extras (needed for tests and running the app)
-poetry install --extras all
-
-# If poetry is broken, use pipx (same project root):
-# pipx run poetry install --no-interaction --extras all
-
-# Or with pip (minimal install first; add extras as needed)
-pip install -e .                  # API + CLI only
-pip install -e ".[all]"           # Full stack (ML, quantum, server)
+pip install -e .                     # start here
+pip install -e ".[ci]"               # before running the full test suite
+pip install -r requirements-dev.txt  # black, pytest, mypy, etc.
 ```
 
-#### 6. Verify Installation
+**Poetry (optional):** If you use Poetry, `poetry install --extras all` works. If Poetry fails, see [Poetry: what to use from now on](POETRY_FIX.md) or stick with `pip install -e ".[all]"`.
+
+**Backend API:** The Node/Worker handler is in [Bleujs.-backend](https://github.com/HelloblueAI/Bleujs.-backend). You do **not** need it for daily `bleu chat` against the hosted API.
+
+#### 4. Verify installation
 
 ```bash
-# Run tests
-pytest
-
-# Check code style
-black --check src/
-isort --check src/
-
-# Type checking
-mypy src/ --ignore-missing-imports
+python -c "import bleujs; print(bleujs.__version__)"
+bleu health                        # needs BLEUJS_API_KEY in .env or environment
+pytest                             # after pip install -e ".[ci]" + requirements-dev.txt
 ```
 
-#### 7. Install Pre-commit Hooks (Optional but Recommended)
+#### 5. Pre-commit hooks (optional)
 
 ```bash
 pre-commit install
 ```
 
-This will automatically run code quality checks before each commit.
+See also [Local development](local-development.md) for running CI checks before you push.
 
 ---
 

--- a/docs/CONTRIBUTOR_GUIDE.md
+++ b/docs/CONTRIBUTOR_GUIDE.md
@@ -31,15 +31,16 @@ cd Bleu.js
 ### 3. Set Up Environment
 
 ```bash
-# Create virtual environment
-python -m venv bleujs-env
-source bleujs-env/bin/activate  # Linux/Mac
-# or
-bleujs-env\Scripts\activate     # Windows
+python -m venv .venv
+source .venv/bin/activate       # Windows: .venv\Scripts\activate
 
-# Install in development mode
-pip install -e ".[dev]"
+pip install -e .                # SDK + CLI (same as requirements.txt)
+echo 'BLEUJS_API_KEY=bleujs_sk_...' > .env
+set -a && source .env && set +a
+bleu chat "Hello"
 ```
+
+Full guide: [Contributing → Development setup](CONTRIBUTING.md#-development-setup). For tests: `pip install -e ".[ci]"` and `pip install -r requirements-dev.txt`.
 
 ### 4. Make a Small Change
 

--- a/docs/DEPENDENCY_MANAGEMENT.md
+++ b/docs/DEPENDENCY_MANAGEMENT.md
@@ -222,11 +222,9 @@ pip install bleu-js              # default includes API client + CLI
 
 ```bash
 # Isolate Bleu.js dependencies
-python -m venv bleujs-env
-source bleujs-env/bin/activate  # Linux/Mac
-# or
-bleujs-env\Scripts\activate     # Windows
-pip install bleu-js
+python -m venv .venv
+source .venv/bin/activate       # Windows: .venv\Scripts\activate
+pip install bleu-js             # from PyPI; contributors: pip install -e .
 ```
 
 **Option 3: Override Versions (Advanced)**

--- a/docs/GET_STARTED.md
+++ b/docs/GET_STARTED.md
@@ -92,6 +92,7 @@ bleu health    # or: bleujs health
 |------|------|
 | **Quick reference** (SDK + CLI) | [QUICKSTART.md](QUICKSTART.md) |
 | **Full API & CLI docs** | [API_CLIENT_GUIDE.md](API_CLIENT_GUIDE.md) |
+| **Hack on the repo** (clone, `pip install -e .`) | [CONTRIBUTING.md → Development setup](CONTRIBUTING.md#-development-setup) |
 | **Install extras** (ML, quantum, etc.) | [INSTALLATION.md](INSTALLATION.md) |
 | **Run examples** | `examples/api_client_basic.py` (needs API key) |
 | **Roadmap & philosophy** | [ROADMAP.md](ROADMAP.md) · [PRODUCT_PHILOSOPHY.md](PRODUCT_PHILOSOPHY.md) |

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -57,20 +57,35 @@ poetry shell
 
 ### Using pip from Source
 
-**For development or self-hosting only.** Most users should use `pip install bleu-js` from PyPI.
+**For contributors and self-hosting only.** Most users should use `pip install bleu-js` from PyPI.
 
 ```bash
-# Clone the repository
 git clone https://github.com/HelloblueAI/Bleu.js.git
 cd Bleu.js
+python -m venv .venv && source .venv/bin/activate
 
-# Install the package (API + CLI, same as PyPI)
-pip install -e .
-
-# Or install with full app dependencies (for running the server)
-pip install -e ".[server]"
-# requirements.txt is used by CI/full stack; prefer pyproject.toml extras.
+pip install -e .                   # SDK + CLI — same as requirements.txt
+echo 'BLEUJS_API_KEY=bleujs_sk_...' > .env
+set -a && source .env && set +a
+bleu chat "Hello"
 ```
+
+**Dependency map** (canonical: `pyproject.toml`; files are CI/deploy wrappers):
+
+| File | Equivalent |
+|------|------------|
+| `requirements.txt` | `pip install -e .` |
+| `requirements-ci.txt` | `pip install -e ".[ci]"` |
+| `requirements-all.txt` | `pip install -e ".[all]"` |
+| `requirements-elasticbeanstalk.txt` | full stack (EB repo-root deploy) |
+| `requirements-dev.txt` | lint/test tools (after editable install) |
+
+```bash
+pip install -e ".[server]"         # self-host FastAPI app (database, uvicorn, …)
+pip install -e ".[ci]"             # run the full test suite locally
+```
+
+**Contributors:** [Development setup](CONTRIBUTING.md#-development-setup).
 
 ---
 
@@ -126,51 +141,37 @@ bleu chat "Hello"
 
 ### Method 2: Development Install (For Contributors)
 
-**Best for:** Developers who want to contribute
+**Best for:** SDK/CLI work against the hosted API at [bleujs.org](https://bleujs.org)
 
 ```bash
-# 1. Clone the repository
 git clone https://github.com/HelloblueAI/Bleu.js.git
 cd Bleu.js
-
-# 2. Install with Poetry (recommended)
-poetry install --with dev
-
-# 3. Activate virtual environment
-poetry shell
-
-# 4. Verify installation
-python3 -c "from src.config import get_settings; print('✅ Bleu.js ready!')"
+python -m venv .venv && source .venv/bin/activate
+pip install -e .
+echo 'BLEUJS_API_KEY=bleujs_sk_...' > .env
+set -a && source .env && set +a
+bleu chat "Hello"
 ```
+
+For the full test suite: `pip install -e ".[ci]"` and `pip install -r requirements-dev.txt`. See [Contributing → Development setup](CONTRIBUTING.md#-development-setup).
 
 ---
 
 ### Method 3: Production Install (For Deployment)
 
-**Best for:** Production servers
+**Best for:** Self-hosting the FastAPI product app
 
 ```bash
-# 1. Clone the repository
 git clone https://github.com/HelloblueAI/Bleu.js.git
 cd Bleu.js
+python3 -m venv .venv && source .venv/bin/activate
 
-# 2. Create virtual environment
-python3 -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
+pip install -e ".[server]"          # or: pip install -r requirements-all.txt for full stack
 
-# 3. Install production dependencies
-pip install -r requirements.txt
-
-# 4. Set up environment
-cp .env.example .env
-# Edit .env with your production settings
-
-# 5. Initialize database
+cp .env.example .env                # set production secrets and DATABASE_URL
 alembic upgrade head
-
-# 6. Start application (product app)
 python main.py
-# Or with workers: python -m uvicorn src.main:app --host 0.0.0.0 --port 8000 --workers 4
+# Or: uvicorn src.main:app --host 0.0.0.0 --port 8000 --workers 4
 ```
 
 ---
@@ -322,54 +323,34 @@ echo "DATABASE_URL=sqlite:///./bleujs.db" >> .env
 uvicorn src.main:app --reload
 ```
 
-### Scenario 2: Local Development
+### Scenario 2: Local Development (contributor)
 
 ```bash
-# Clone and setup
 git clone https://github.com/HelloblueAI/Bleu.js.git
 cd Bleu.js
-poetry install --with dev
-poetry shell
+python -m venv .venv && source .venv/bin/activate
+pip install -e .
+pip install -e ".[ci]" && pip install -r requirements-dev.txt   # for pytest
 
-# Setup environment
-cp .env.example .env
-# Edit .env with your settings
-
-# Initialize database
-alembic upgrade head
-
-# Run tests
+echo 'BLEUJS_API_KEY=bleujs_sk_...' > .env
+set -a && source .env && set +a
+bleu chat "Hello"
 pytest
-
-# Start development server
-uvicorn src.main:app --reload --port 8000
 ```
+
+Self-hosting the app locally? Add `pip install -e ".[server]"`, copy `.env.example` → `.env`, `alembic upgrade head`, then `uvicorn src.main:app --reload`.
 
 ### Scenario 3: Production Deployment
 
 ```bash
-# Clone specific version
 git clone --branch v1.2.1 https://github.com/HelloblueAI/Bleu.js.git
 cd Bleu.js
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e ".[server]"          # or requirements-all.txt for full stack
 
-# Setup production environment
-python3 -m venv venv
-source venv/bin/activate
-pip install -r requirements.txt
-
-# Configure for production
 cp .env.example .env
-# Set production secrets and DATABASE_URL
-
-# Initialize database
 alembic upgrade head
-
-# Run with multiple workers
-uvicorn src.main:app \
-  --host 0.0.0.0 \
-  --port 8000 \
-  --workers 4 \
-  --log-level info
+uvicorn src.main:app --host 0.0.0.0 --port 8000 --workers 4 --log-level info
 ```
 
 ### Scenario 4: Docker Deployment
@@ -415,43 +396,33 @@ curl http://localhost:8000/health
 sudo apt update
 sudo apt install python3.11 python3-pip python3-venv git
 
-# Install Bleu.js
+# Clone and install (SDK + CLI)
 git clone https://github.com/HelloblueAI/Bleu.js.git
 cd Bleu.js
-python3 -m venv venv
-source venv/bin/activate
-pip install -r requirements.txt
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e .                    # self-host app: pip install -e ".[server]"
 ```
 
 ### macOS
 
 ```bash
-# Install Python (if not installed)
 brew install python@3.11
-
-# Install Bleu.js
 git clone https://github.com/HelloblueAI/Bleu.js.git
 cd Bleu.js
-python3 -m venv venv
-source venv/bin/activate
-pip install -r requirements.txt
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e .
 ```
 
 ### Windows
 
 ```powershell
-# Install Python from python.org first
-
-# Clone repository
 git clone https://github.com/HelloblueAI/Bleu.js.git
 cd Bleu.js
-
-# Create virtual environment
-python -m venv venv
-venv\Scripts\activate
-
-# Install dependencies
-pip install -r requirements.txt
+python -m venv .venv
+.venv\Scripts\activate
+pip install -e .
 ```
 
 ---
@@ -525,20 +496,17 @@ poetry install --no-interaction
 ### Issue: Dependencies conflict
 
 ```bash
-# Use pip instead
-pip install -r requirements.txt
+# Fresh venv + editable install (add [ci] or [all] only if you need them)
+rm -rf .venv && python -m venv .venv && source .venv/bin/activate
+pip install -U pip
+pip install -e .
 ```
 
 ### Issue: Import errors
 
 ```bash
-# Ensure you're in the right directory
 cd /path/to/Bleu.js
-
-# Ensure virtual environment is activated
-source venv/bin/activate  # or poetry shell
-
-# Reinstall
+source .venv/bin/activate
 pip install -e .
 ```
 
@@ -644,7 +612,7 @@ After successful installation:
 1. **Cloud API users:** [Get started](GET_STARTED.md) · [QUICKSTART](QUICKSTART.md)
 2. **Self-host / dev:** Review [`.env.example`](../.env.example); run `uvicorn src.main:app --reload`
 3. **Explore API (when app running):** http://localhost:8000/docs
-4. **Run tests (contributors):** `pytest --cov=src`
+4. **Run tests (contributors):** `pip install -e ".[ci]"` then `pytest --cov=src`
 5. **Docs:** `docs/` directory
 
 ---

--- a/docs/INSTALLATION_GUIDE.md
+++ b/docs/INSTALLATION_GUIDE.md
@@ -68,10 +68,10 @@ pip install "bleu-js[all]"
 ### **Option 5: Development Installation**
 
 ```bash
-# Clone and install in development mode
 git clone https://github.com/HelloblueAI/Bleu.js.git
 cd Bleu.js
-pip install -e ".[dev]"
+python -m venv .venv && source .venv/bin/activate
+pip install -e .                  # SDK + CLI; see CONTRIBUTING.md#-development-setup
 ```
 
 ## 🔧 Troubleshooting
@@ -94,8 +94,8 @@ error: resolution-too-deep
 pip install "bleu-js[ml]" --constraint requirements-basic.txt
 
 # Or use a virtual environment
-python3 -m venv bleujs-env
-source bleujs-env/bin/activate
+python3 -m venv .venv
+source .venv/bin/activate
 pip install bleu-js
 ```
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -7,22 +7,21 @@ Welcome to the Bleu.js community! This guide will help you get started as a cont
 ### 1. Set Up Your Environment
 
 ```bash
-# Clone the repository
 git clone https://github.com/HelloblueAI/Bleu.js.git
 cd Bleu.js
 
-# Create virtual environment
-python -m venv bleujs-env
-source bleujs-env/bin/activate  # Linux/Mac
-# or
-bleujs-env\Scripts\activate     # Windows
+python -m venv .venv
+source .venv/bin/activate       # Windows: .venv\Scripts\activate
 
-# Install in development mode
-pip install -e ".[dev]"
+pip install -e .
+echo 'BLEUJS_API_KEY=bleujs_sk_...' > .env
+set -a && source .env && set +a
 
-# Verify installation
-python -c "from bleujs import BleuJS; print('✅ Setup complete!')"
+bleu chat "Hello"
+python -c "import bleujs; print('✅', bleujs.__version__)"
 ```
+
+See [Contributing → Development setup](CONTRIBUTING.md#-development-setup). For `pytest`: `pip install -e ".[ci]"` and `pip install -r requirements-dev.txt`.
 
 ### 2. Run Tests
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -1,5 +1,9 @@
 # 🚀 Quick Start Guide - Bleu.js
 
+> **Using the hosted API?** Start with [Get started](GET_STARTED.md) (`pip install bleu-js` from PyPI).
+> **Contributing from a clone?** See [Development setup](CONTRIBUTING.md#-development-setup) (`pip install -e .`).
+> This page is for **self-hosting** the FastAPI app.
+
 ## ⚡ Get Running in 5 Minutes
 
 ### Step 1: Generate Secrets (1 min)
@@ -44,7 +48,8 @@ EOF
 ### Step 3: Install Dependencies (2 min)
 
 ```bash
-pip install -r requirements.txt
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[server]"       # self-host stack; SDK-only: pip install -e .
 ```
 
 ### Step 4: Initialize Database (30 sec)
@@ -108,7 +113,7 @@ uvicorn src.api.main:app --reload --port 8001
 
 ```bash
 pip install --upgrade pip
-pip install -r requirements.txt --no-cache-dir
+pip install -e ".[server]" --no-cache-dir
 ```
 
 **Database errors?**

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,8 @@ pip install git+https://github.com/HelloblueAI/Bleu.js.git
 # Or clone and install (contributors)
 git clone https://github.com/HelloblueAI/Bleu.js.git
 cd Bleu.js
-poetry install
+python -m venv .venv && source .venv/bin/activate
+pip install -e .                  # see CONTRIBUTING.md#-development-setup
 ```
 
 **Requires Python 3.11+**
@@ -268,12 +269,11 @@ git clone https://github.com/HelloblueAI/Bleu.js.git
 cd Bleu.js
 
 # Create and activate virtual environment
-python -m venv bleujs-env
+python -m venv .venv
+source .venv/bin/activate
 
-# Install dependencies
-pip install -r requirements.txt
-
-# Install development dependencies
+pip install -e .                  # SDK + CLI (same as requirements.txt)
+pip install -e ".[ci]"              # optional: full test stack
 pip install -r requirements-dev.txt
 ```
 
@@ -307,9 +307,9 @@ Here's how Bleu.js works in a real terminal session:
 # Clone and setup Bleu.js
 $ git clone https://github.com/HelloblueAI/Bleu.js.git
 $ cd Bleu.js
-$ python -m venv bleujs-env
-$ source bleujs-env/bin/activate
-$ pip install -r requirements.txt
+$ python -m venv .venv
+$ source .venv/bin/activate
+$ pip install -e .
 
 # Run the comprehensive sample
 $ python examples/sample_usage.py
@@ -1213,14 +1213,11 @@ pie title System Performance Metrics
 git clone https://github.com/HelloblueAI/Bleu.js.git
 cd Bleu.js
 
-# Create and activate virtual environment
-python -m venv bleujs-env
-
-# Install dependencies
-pip install -r requirements.txt
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+pip install -e ".[ci]"
 pip install -r requirements-dev.txt
-
-# Install pre-commit hooks
 pre-commit install
 ```
 

--- a/docs/RESOURCE_REQUIREMENTS.md
+++ b/docs/RESOURCE_REQUIREMENTS.md
@@ -190,8 +190,8 @@ pip install 'bleu-js[all]'
 
    ```bash
    # Isolate to avoid conflicts
-   python -m venv bleujs-env
-   source bleujs-env/bin/activate
+   python -m venv .venv
+   source .venv/bin/activate
    pip install bleu-js
    ```
 

--- a/docs/USER_CONCERNS_AND_FAQ.md
+++ b/docs/USER_CONCERNS_AND_FAQ.md
@@ -129,8 +129,8 @@ pip install bleu-js              # default includes API client + CLI
 
 ```bash
 # Isolate Bleu.js dependencies
-python -m venv bleujs-env
-source bleujs-env/bin/activate
+python -m venv .venv
+source .venv/bin/activate
 pip install bleu-js
 ```
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,5 +1,7 @@
 # Local Development Guide
 
+**Environment setup** (venv, `pip install -e .`, `.env`): [Contributing → Development setup](CONTRIBUTING.md#-development-setup).
+
 This guide shows you how to run CI/CD checks locally to catch issues before pushing to GitHub.
 
 ## Quick Start

--- a/scripts/export_requirements.sh
+++ b/scripts/export_requirements.sh
@@ -7,6 +7,7 @@ cd "$ROOT"
 
 cat <<'EOF'
 Bleu.js dependency installs (canonical source: pyproject.toml)
+  Contributor guide: docs/CONTRIBUTING.md#-development-setup
 
   Users (PyPI):     pip install bleu-js
   Dev SDK/CLI:      pip install -e .


### PR DESCRIPTION
## Summary
- Adds **For developers** to the README (clone → `.venv` → `pip install -e .` → `.env` → `bleu chat`)
- Makes `docs/CONTRIBUTING.md` → **Development setup** the canonical contributor guide with a requirements/extras table
- Aligns INSTALLATION, onboarding, contributor guide, GET_STARTED, and QUICK_START with the slim editable-install model
- Standardizes on `.venv` (not `bleujs-env`) and clarifies `requirements.txt` = `-e .` (not a full ML stack)
- Distinguishes **PyPI users**, **SDK contributors**, and **self-host** (`pip install -e ".[server]"` / `[ci]` / `[all]`)

## Test plan
- [x] Docs only — no code changes
- [ ] Review README "For developers" block reads clearly for new contributors
- [ ] Squash merge when happy (CI may skip or run docs checks per repo config)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or dependency code touched; risk is limited to contributors following outdated steps in unmigrated pages.
> 
> **Overview**
> This PR **unifies contributor and clone-from-source docs** around one workflow: `.venv`, **`pip install -e .`** for SDK/CLI, root **`.env`** with **`BLEUJS_API_KEY`**, and **`bleu chat`** against the hosted API.
> 
> **README** and root **CONTRIBUTING** gain a short “develop from source” path and links into **`docs/CONTRIBUTING.md` → Development setup**, which is reframed as the **canonical** guide (daily SDK workflow, extras table mapping **`pyproject.toml`** to **`requirements*.txt`**, Poetry optional, Node backend not required for `bleu chat`).
> 
> Across **INSTALLATION**, **GET_STARTED**, **onboarding**, **contributor guides**, **QUICK_START** (now labeled self-host vs PyPI vs clone), and related pages, instructions shift **away from** default **`poetry install`**, **`pip install -r requirements.txt`**, and **`bleujs-env`** toward **`.venv`**, **`-e .` / `-[ci]` / `-[server]` / `-[all]`**, and clearer splits between **PyPI users**, **SDK contributors**, and **self-host**. **`scripts/export_requirements.sh`** points maintainers at the same contributor section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a06880c7974841c5dafedf5d9f7cb6c8eddb4242. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->