### PR TITLE
fix(ci): run main workflow on docs-only pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,13 +9,10 @@ on:
       - '.github/*.md'
       - 'LICENSE'
       - 'CHANGELOG.md'
+  # Run CI on every PR (including docs-only) so branch ruleset required checks
+  # can pass. push.paths-ignore below still skips post-merge doc-only pushes.
   pull_request:
     branches: [main, staging]
-    paths-ignore:
-      - '*.md'
-      - 'docs/**'
-      - '.github/*.md'
-      - 'LICENSE'
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
## Summary
Removes `paths-ignore` from the `pull_request` trigger in `main.yml` so documentation-only PRs run the four checks required by the **protect main** ruleset (lint, security, tests, pipeline summary).

`push.paths-ignore` is unchanged — doc-only commits merged to `main` still skip the heavy workflow after merge.

## Why
PR #212 (docs-only) was merge-blocked until we touched `scripts/export_requirements.sh` to force CI. Contributors following the new CONTRIBUTING guide should not need that workaround.

## Test plan
- [x] YAML validates (pre-commit `check yaml`)
- [ ] This PR runs full main CI (workflow change)
- [ ] After merge, a docs-only PR should show all four required checks without extra file changes


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow trigger-only change with no application code; docs-only PRs will use more CI minutes.
> 
> **Overview**
> **Docs-only PRs to `main`/`staging` now always run the full `main.yml` CI pipeline** by dropping `paths-ignore` on the `pull_request` trigger. Inline comments note this is so branch ruleset required checks (lint, security, tests, pipeline summary) can complete without contributors touching non-doc files.
> 
> **Post-merge behavior is unchanged:** `push` still uses `paths-ignore` for markdown, `docs/**`, license, and changelog, so doc-only commits on protected branches continue to skip the heavy workflow after merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f4797bd60599871bd9eb590a5253f0259b74a6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->