### PR TITLE
docs: align repository map with bleujs.org production API ownership

### DIFF
--- a/docs/BACKEND_REPO.md
+++ b/docs/BACKEND_REPO.md
@@ -50,8 +50,10 @@ If you create a new repo, use the same remote URL; existing repo: [Bleujs.-backe
 
 ## After the backend repo exists
 
-- **CI/CD:** Add GitHub Actions in the backend repo for test, lint, deploy.
-- **Deploy:** Point bleujs.org API at the backend repo’s main branch or releases.
+- **CI/CD:** GitHub Actions in the backend repo handle test, lint, and ML script validation.
+- **Deploy chat/generate/embed:** Production routes are on **bleujs.org** (Next.js), not this backend repo. See [Who serves the API](./WHO_SERVES_THE_API.md).
+- **Deploy `/predict`:** Use the backend repo's **Python FastAPI** service (`predict_api.py`) via Docker, Railway, or Elastic Beanstalk.
+- **Deploy Node stub (optional):** Use `index.mjs` only for local dev, CI, or edge stub hosting — not for production AI.
 - **Link:** Backend repo: [github.com/HelloblueAI/Bleujs.-backend](https://github.com/HelloblueAI/Bleujs.-backend).
 
 **Backend repo parity (recommended):** So both repos feel production-ready, the backend repo should have: a minimal CI (lint + test), a README with install/run instructions, and a SECURITY.md (reporting, no secrets, deployment checklist). This repo’s [SECURITY.md](../SECURITY.md) can be used as a template.

--- a/docs/REPOSITORIES.md
+++ b/docs/REPOSITORIES.md
@@ -7,20 +7,23 @@ The **Bleu.js project** is split across two repositories so each stays focused, 
 | Repository | Purpose | Primary audience |
 |------------|---------|------------------|
 | **[Bleu.js](https://github.com/HelloblueAI/Bleu.js)** | Python SDK, CLI, docs, demos, product app (bleujs.org surface), Railway Docker image | Users, SDK/CLI contributors, doc contributors |
-| **[Bleujs.-backend](https://github.com/HelloblueAI/Bleujs.-backend)** | Node/Express API, ML inference, rules engine, services that power the cloud API | Backend contributors, DevOps |
+| **[Bleujs.-backend](https://github.com/HelloblueAI/Bleujs.-backend)** | Node edge stub (contract compliance), Python `/predict` (XGBoost FastAPI) | Backend contributors, DevOps |
 
 The backend repo’s canonical name is **Bleujs.-backend** (with the dot); URL: `https://github.com/HelloblueAI/Bleujs.-backend`.
 
 ## How they work together
 
 ```
-Users / SDK / CLI  →  bleujs.org (product)  →  Backend API (Bleujs.-backend)
+Users / SDK / CLI  →  api.bleujs.org  →  bleujs.org (Next.js) — chat / generate / embed
                           ↑
-                    This repo (Bleu.js): SDK, CLI, docs, dashboard
+                    This repo (Bleu.js): SDK, CLI, docs, product app
+
+ML clients  →  Bleujs.-backend (Python FastAPI) — POST /predict
+Local / CI  →  Bleujs.-backend (Node index.mjs) — stub + contract tests
 ```
 
-- **This repo (Bleu.js):** Users install `bleu-js`, use the CLI and SDK, and read the docs. The product app (e.g. bleujs.org) is also built from this repo.
-- **Backend repo:** The API that the SDK and CLI call (chat, generate, embed, etc.) is implemented and deployed from the backend repo. Deployments point bleujs.org (or your API URL) at the backend’s main branch or releases.
+- **This repo (Bleu.js):** Users install `bleu-js`, use the CLI and SDK, and read the docs. The product app surface is documented here; the live site is **bleujs.org**.
+- **Backend repo:** **Production chat/generate/embed → bleujs.org.** **`/predict` → Python FastAPI** in Bleujs.-backend. **Node handler → edge stub + contract compliance** (local dev, CI, optional Workers). See [Who serves the API](WHO_SERVES_THE_API.md) and the [backend README](https://github.com/HelloblueAI/Bleujs.-backend#who-serves-what-in-production).
 
 ## Keeping client and backend in sync
 


### PR DESCRIPTION
## Summary
- Clarify in `REPOSITORIES.md` that production chat/generate/embed are served by bleujs.org (Next.js), not Bleujs.-backend
- Update `BACKEND_REPO.md` deploy guidance to separate bleujs.org API routes from backend `/predict` and the Node contract stub

## Test plan
- [x] Docs-only change; pre-commit hooks passed on commit

Made with [Cursor](https://cursor.com)