### PR TITLE
docs: link good first issues in contributor guide (OSS PR 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - **OSS cleanup (PR 1):** Move maintainer handoffs and ops runbooks to `docs/archive/maintainer/`; refresh `docs/archive/README.md`; update contributor doc links.
 - **OSS cleanup (PR 2):** Slim README (~1,100 → ~180 lines); extract content to `docs/PLATFORM_OVERVIEW.md`, `docs/ACHIEVEMENTS.md`, `docs/PERFORMANCE.md`, and archived Docker Compose reference.
 - **OSS cleanup (PR 3–4):** Add `IP_AND_CONTRIBUTIONS.md`, archive patent/award drafts under `docs/archive/ip/`; PyPI homepage/repository/documentation URLs and `PACKAGE_MAP.md`.
+- **OSS cleanup (PR 7):** Seed good first issues #234–#238; link from `CONTRIBUTOR_GUIDE.md`.
 
 ### Removed
 - **Bleu OS** — Removed `bleu-os/` tree, `bleu-os.yml` and `docker-publish.yml` workflows, and Docker Hub publish path. Railway and self-host use the root [Dockerfile](Dockerfile) with [deploy/requirements-server.txt](deploy/requirements-server.txt). The `bleuos/bleu-os` images on Docker Hub are retired (no longer built from this repo).

--- a/docs/CONTRIBUTOR_GUIDE.md
+++ b/docs/CONTRIBUTOR_GUIDE.md
@@ -6,18 +6,17 @@ Welcome! This guide will help you make your first contribution to Bleu.js.
 
 ### 1. Find Something to Work On
 
-**Good First Issues:**
+**Good First Issues (open now):**
 
-- 🔍 Look for issues labeled `good first issue` or `help wanted` (maintainers aim to keep 3–5 such issues labeled for new contributors)
-- 📝 Fix typos in documentation
-- 🧪 Add missing tests
-- 📚 Improve examples
-- 🐛 Fix small bugs
+| Issue | Topic |
+|-------|--------|
+| [#234](https://github.com/HelloblueAI/Bleu.js/issues/234) | Unit tests for `BleuAPIClient` timeout handling |
+| [#235](https://github.com/HelloblueAI/Bleu.js/issues/235) | Onboarding links in `examples/README.md` |
+| [#236](https://github.com/HelloblueAI/Bleu.js/issues/236) | Document `[server]` env vars in `INSTALLATION.md` |
+| [#237](https://github.com/HelloblueAI/Bleu.js/issues/237) | Markdown link check in CI (`help wanted`) |
+| [#238](https://github.com/HelloblueAI/Bleu.js/issues/238) | OpenAPI chat response examples (`help wanted`) |
 
-**Where to Look:**
-
-- [GitHub Issues](https://github.com/HelloblueAI/Bleu.js/issues)
-- Filter by: `good first issue`, `help wanted`, `beginner-friendly`
+Also browse [all good first issues](https://github.com/HelloblueAI/Bleu.js/issues?q=is%3Aopen+label%3A%22good+first+issue%22) or [help wanted](https://github.com/HelloblueAI/Bleu.js/issues?q=is%3Aopen+label%3A%22help+wanted%22).
 
 ### 2. Fork and Clone
 

--- a/docs/OSS_CLEANUP_PLAN.md
+++ b/docs/OSS_CLEANUP_PLAN.md
@@ -290,9 +290,9 @@ One paragraph in `CONTRIBUTING.md`: “**Canonical package is `bleu-js` at repo 
 
 ---
 
-## PR 7 — Good first issues + contributor funnel (Bleu.js, GitHub UI)
+## PR 7 — Good first issues + contributor funnel (Bleu.js) ✅ *Done 2026-06-23*
 
-**Branch:** N/A — GitHub labels + 3–5 issues
+**Branch:** N/A — GitHub labels + issues
 **Can run in parallel with PR 1–2**
 
 ### Create labels
@@ -315,8 +315,9 @@ Reference them from `CONTRIBUTOR_GUIDE.md` (already mentions 3–5 issues).
 
 ### Acceptance criteria
 
-- [ ] ≥3 open `good first issue` at all times
-- [ ] Each issue has “Expected outcome” + “How to verify”
+- [x] ≥3 open `good first issue` at all times ([#234](https://github.com/HelloblueAI/Bleu.js/issues/234), [#235](https://github.com/HelloblueAI/Bleu.js/issues/235), [#236](https://github.com/HelloblueAI/Bleu.js/issues/236))
+- [x] Each issue has “Expected outcome” + “How to verify”
+- [x] `CONTRIBUTOR_GUIDE.md` links to starter issues
 
 ---
 


### PR DESCRIPTION
## Summary
- Issues #234–#238 created on GitHub (3× `good first issue`, 2× `help wanted`)
- `CONTRIBUTOR_GUIDE.md` lists starter issues with direct links
- `OSS_CLEANUP_PLAN.md` PR 7 marked complete

## Test plan
- [x] Issue links resolve on GitHub
- [x] Docs-only change

Made with [Cursor](https://cursor.com)