### PR TITLE
docs: add examples onboarding links

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -48,3 +48,7 @@ python examples/quick_start.py
 ---
 
 **First time?** Use [Get started](../docs/GET_STARTED.md) for install → API key → first command.
+
+For API-focused examples, see the [API Client Guide](../docs/API_CLIENT_GUIDE.md).
+
+Want to make your first PR? Start with the [Contributor Guide](../docs/CONTRIBUTOR_GUIDE.md).


### PR DESCRIPTION
## Summary

- Adds the API Client Guide link to `examples/README.md`.
- Adds a first-PR pointer to the Contributor Guide.
- Keeps the existing Get Started link in place.

Closes #235

## Verification

- `git diff --check origin/main...HEAD`
- Confirmed these relative links are present and resolve to existing files:
  - `../docs/GET_STARTED.md`
  - `../docs/API_CLIENT_GUIDE.md`
  - `../docs/CONTRIBUTOR_GUIDE.md`