### PR TITLE
fix(sdk): normalize generate().text and release 1.5.41

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -231,7 +231,8 @@ jobs:
   lint:
     name: 🧹 Code Quality & Linting
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Poetry install regularly exceeds 10m on cold runners; keep headroom for flake8/black.
+    timeout-minutes: 20
 
     steps:
       - name: Free Disk Space

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "bleu-js"
-version = "1.5.40"
+version = "1.5.41"
 description = "Advanced AI and Quantum Computing Framework"
 authors = ["Bleujs Team <support@helloblue.ai>"]
 readme = "README.md"

--- a/src/bleu_ai/__init__.py
+++ b/src/bleu_ai/__init__.py
@@ -4,7 +4,7 @@ Bleujs - Quantum-Enhanced AI Platform
 A state-of-the-art quantum-enhanced vision system with advanced AI capabilities.
 """
 
-__version__ = "1.5.40"
+__version__ = "1.5.41"
 
 # Optional API client import
 try:

--- a/src/bleujs/__init__.py
+++ b/src/bleujs/__init__.py
@@ -25,7 +25,7 @@ Machine Learning:
 For more examples, see: https://github.com/HelloblueAI/Bleu.js
 """
 
-__version__ = "1.5.40"
+__version__ = "1.5.41"
 __author__ = "Bleujs Team"
 __email__ = "support@helloblue.ai"
 __license__ = "MIT"

--- a/src/bleujs/api_client/_shared.py
+++ b/src/bleujs/api_client/_shared.py
@@ -188,7 +188,8 @@ def normalize_generate_response(raw: Any) -> Dict[str, Any]:
     """
     Normalize generate API response to the shape expected by GenerationResponse.
 
-    Handles: dict with "text", bare string, list (first element), or None.
+    Handles: dict with "text", OpenAI-style choices[].message.content /
+    choices[].text, bare string, list (first element), or None.
     """
     if raw is None:
         logger.debug("Generate response was None; normalizing to empty text.")
@@ -235,14 +236,42 @@ def normalize_generate_response(raw: Any) -> Dict[str, Any]:
             "usage": None,
             "finish_reason": None,
         }
+
+    text = raw.get("text")
+    finish_reason = raw.get("finish_reason")
+    if not isinstance(text, str) or not text:
+        choices = raw.get("choices") or []
+        if isinstance(choices, list) and choices:
+            first = choices[0] if isinstance(choices[0], dict) else None
+            if first is not None:
+                message = (
+                    first.get("message")
+                    if isinstance(first.get("message"), dict)
+                    else {}
+                )
+                content = message.get("content") if message else None
+                choice_text = first.get("text")
+                if isinstance(content, str) and content:
+                    text = content
+                    logger.debug(
+                        "Generate response used choices[0].message.content; normalizing."
+                    )
+                elif isinstance(choice_text, str) and choice_text:
+                    text = choice_text
+                    logger.debug("Generate response used choices[0].text; normalizing.")
+                if finish_reason is None and first.get("finish_reason") is not None:
+                    finish_reason = first.get("finish_reason")
+        if not isinstance(text, str):
+            text = ""
+
     return {
         "id": raw.get("id", ""),
         "object": raw.get("object", "text.completion"),
         "created": raw.get("created", 0),
         "model": raw.get("model", ""),
-        "text": raw.get("text", ""),
+        "text": text,
         "usage": raw.get("usage"),
-        "finish_reason": raw.get("finish_reason"),
+        "finish_reason": finish_reason,
     }
 
 

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -4,7 +4,7 @@ Bleu configuration module.
 This module provides configuration management for Bleu.js.
 """
 
-__version__ = "1.5.40"
+__version__ = "1.5.41"
 
 from functools import lru_cache
 

--- a/src/quantum_py/__init__.py
+++ b/src/quantum_py/__init__.py
@@ -4,5 +4,5 @@ Quantum Python module for Bleu.js.
 This module provides quantum computing capabilities and utilities.
 """
 
-__version__ = "1.5.40"
+__version__ = "1.5.41"
 __author__ = "Bleu.js Team"

--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -4,7 +4,7 @@ Bleu schemas module.
 This module provides data schemas for Bleu.js.
 """
 
-__version__ = "1.5.40"
+__version__ = "1.5.41"
 
 from .auth import TokenData
 

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -308,6 +308,63 @@ class TestTextGeneration:
         assert isinstance(response, GenerationResponse)
         assert response.text == "Just the generated text"
 
+    @patch("httpx.Client.request")
+    def test_generate_openai_style_choices_response(self, mock_request, client):
+        """Test generate when API returns choices[].message.content without top-level text."""
+        mock_request.return_value = Mock(
+            status_code=200,
+            json=lambda: {
+                "id": "gen_123",
+                "object": "text_completion",
+                "created": 1234567890,
+                "model": "bleujs-xgboost-v1",
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "Soft rain on glass—a quiet street.",
+                        },
+                        "index": 0,
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 6,
+                    "completion_tokens": 12,
+                    "total_tokens": 18,
+                },
+            },
+        )
+        response = client.generate("Write a haiku about rain")
+        assert isinstance(response, GenerationResponse)
+        assert response.text == "Soft rain on glass—a quiet street."
+        assert response.finish_reason == "stop"
+        assert response.model == "bleujs-xgboost-v1"
+
+    @patch("httpx.Client.request")
+    def test_generate_prefers_top_level_text_over_choices(self, mock_request, client):
+        """Top-level text wins when both text and choices are present."""
+        mock_request.return_value = Mock(
+            status_code=200,
+            json=lambda: {
+                "id": "gen_456",
+                "object": "text_completion",
+                "created": 1234567890,
+                "model": "bleu-gen-v1",
+                "text": "Canonical text field",
+                "choices": [
+                    {
+                        "message": {"role": "assistant", "content": "Ignored choice"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "finish_reason": "length",
+            },
+        )
+        response = client.generate("Prompt")
+        assert response.text == "Canonical text field"
+        assert response.finish_reason == "length"
+
 
 class TestEmbeddings:
     """Test embeddings functionality"""

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -365,6 +365,48 @@ class TestTextGeneration:
         assert response.text == "Canonical text field"
         assert response.finish_reason == "length"
 
+    @patch("httpx.Client.request")
+    def test_generate_choices_legacy_text_field(self, mock_request, client):
+        """Fall back to choices[0].text when message.content is absent."""
+        mock_request.return_value = Mock(
+            status_code=200,
+            json=lambda: {
+                "id": "gen_legacy",
+                "object": "text_completion",
+                "created": 1234567890,
+                "model": "bleu-gen-v1",
+                "choices": [
+                    {
+                        "text": "Legacy completion text",
+                        "index": 0,
+                        "finish_reason": "stop",
+                    }
+                ],
+            },
+        )
+        response = client.generate("Prompt")
+        assert isinstance(response, GenerationResponse)
+        assert response.text == "Legacy completion text"
+        assert response.finish_reason == "stop"
+
+    @patch("httpx.Client.request")
+    def test_generate_empty_when_no_usable_text(self, mock_request, client):
+        """Non-string top-level text with empty choices normalizes to empty string."""
+        mock_request.return_value = Mock(
+            status_code=200,
+            json=lambda: {
+                "id": "gen_empty",
+                "object": "text_completion",
+                "created": 1234567890,
+                "model": "bleu-gen-v1",
+                "text": None,
+                "choices": [],
+            },
+        )
+        response = client.generate("Prompt")
+        assert isinstance(response, GenerationResponse)
+        assert response.text == ""
+
 
 class TestEmbeddings:
     """Test embeddings functionality"""


### PR DESCRIPTION
## Summary
- Fix `normalize_generate_response` to read top-level `text`, then `choices[0].message.content`, then `choices[0].text`
- Bump package version to **1.5.41** and cover the normalize paths with unit tests

## Test plan
- [ ] `pytest tests/test_api_client.py -k generate` (or full `tests/test_api_client.py`)
- [ ] Against production: `BleuAPIClient(...).generate(...).text` is non-empty and not scaffolding
- [ ] After merge, confirm auto-release / publish `bleu-js==1.5.41` on PyPI


Made with [Cursor](https://cursor.com)